### PR TITLE
Add test that verifies embeddings aren't supported

### DIFF
--- a/src/xAI.Protocol/Extensions.cs
+++ b/src/xAI.Protocol/Extensions.cs
@@ -19,7 +19,7 @@ public static class GrpcExtensions
         }
 
         /// <summary>Lists available embedding models.</summary>
-        public async Task<IEnumerable<EmbeddingModel>> ListEmbeddingModelsAsync(CancellationToken cancellation)
+        public async Task<IEnumerable<EmbeddingModel>> ListEmbeddingModelsAsync(CancellationToken cancellation = default)
         {
             var models = await client.ListEmbeddingModelsAsync(new Empty(), cancellationToken: cancellation);
             return models.Models;

--- a/src/xAI.Tests/SanityChecks.cs
+++ b/src/xAI.Tests/SanityChecks.cs
@@ -11,6 +11,21 @@ namespace xAI.Tests;
 public class SanityChecks(ITestOutputHelper output)
 {
     [SecretsFact("CI_XAI_API_KEY")]
+    public async Task NoEmbeddingModels()
+    {
+        var services = new ServiceCollection()
+            .AddxAIProtocol(Environment.GetEnvironmentVariable("CI_XAI_API_KEY")!)
+            .BuildServiceProvider();
+
+        var client = services.GetRequiredService<Models.ModelsClient>();
+
+        var embeddings = await client.ListEmbeddingModelsAsync();
+
+        Assert.NotNull(embeddings);
+        Assert.Empty(embeddings);
+    }
+
+    [SecretsFact("CI_XAI_API_KEY")]
     public async Task ListModelsAsync()
     {
         var services = new ServiceCollection()


### PR DESCRIPTION
xAI currently returns no embedding models, which is the reason we don't provide an IEmbeddingGenerator implementation. If this changes in the future, this new test will fail and we can fix that by providing an implementation then.