### PR TITLE
Add http file showcasing how to use the management API

### DIFF
--- a/src/xAI.Tests/.gitignore
+++ b/src/xAI.Tests/.gitignore
@@ -1,0 +1,1 @@
+http-client.env.json

--- a/src/xAI.Tests/management.http
+++ b/src/xAI.Tests/management.http
@@ -1,0 +1,35 @@
+### List API keys
+GET https://management-api.x.ai/auth/teams/{{teamId}}/api-keys
+Authorization: Bearer {{token}}
+
+### List ACL values
+GET https://management-api.x.ai/auth/teams/{{teamId}}/endpoints
+Authorization: Bearer {{token}}
+
+### List models
+GET https://management-api.x.ai/auth/teams/{{teamId}}/models
+Authorization: Bearer {{token}}
+
+### Validate management key
+GET https://management-api.x.ai/auth/management-keys/validation
+Authorization: Bearer {{token}}
+
+### Create API key
+POST https://management-api.x.ai/auth/teams/{{teamId}}/api-keys
+Authorization: Bearer {{token}}
+
+  {
+    "name": "kzu-user",
+    "acls": [
+      "api-key:endpoint:*",
+      "api-key:model:*"
+    ]
+  }
+
+### Check API Key
+GET https://management-api.x.ai/auth/api-keys/{{userKeyId}}/propagation
+Authorization: Bearer {{token}}
+
+### Delete the key
+DELETE https://management-api.x.ai/auth/api-keys/{{userKeyId}}
+Authorization: Bearer {{token}}


### PR DESCRIPTION
No public client for now since it deviates from the gRPC protocol for everything else. Perhaps we'll introduce a typed API at some point?

To send the requests, users should create an http-client.env.json alongside the http file with the following content:

```json
{
  "management": {
    "teamId": "...",
    "token": "...",
    "userKey": "[after sending the create key request]",
    "userKeyId": "[after sending the create key request]"
  }
}
```