### PR TITLE
Don't force inline citations by default

### DIFF
--- a/src/xAI/GrokChatClient.cs
+++ b/src/xAI/GrokChatClient.cs
@@ -134,8 +134,6 @@ class GrokChatClient : IChatClient
     {
         var request = options?.RawRepresentationFactory?.Invoke(this) as GetCompletionsRequest ?? new GetCompletionsRequest()
         {
-            // By default always include citations in the final output if available
-            Include = { IncludeOption.InlineCitations },
             Model = options?.ModelId ?? defaultModelId,
         };
 
@@ -220,11 +218,9 @@ class GrokChatClient : IChatClient
             request.Messages.Add(gmsg);
         }
 
-        IList<IncludeOption> includes = [IncludeOption.InlineCitations];
+        IList<IncludeOption> includes = [];
         if (options is GrokChatOptions grokOptions)
         {
-            // NOTE: overrides our default include for inline citations, potentially.
-            request.Include.Clear();
             request.Include.AddRange(grokOptions.Include);
 
             if (grokOptions.Search.HasFlag(GrokSearch.X))

--- a/src/xAI/GrokChatOptions.cs
+++ b/src/xAI/GrokChatOptions.cs
@@ -27,6 +27,5 @@ public class GrokChatOptions : ChatOptions
     public GrokSearch Search { get; set; } = GrokSearch.None;
 
     /// <summary>Additional outputs to include in responses.</summary>
-    /// <remarks>Defaults to including <see cref="IncludeOption.InlineCitations"/>.</remarks>
-    public IList<IncludeOption> Include { get; set; } = [IncludeOption.InlineCitations];
+    public IList<IncludeOption> Include { get; set; } = [];
 }


### PR DESCRIPTION
Inline citations assume the client will know how to process/render markdown-style inline links. We shouldn't assume that's the case.