### PR TITLE
fix: remove empty Content block from tool-call-only messages

### DIFF
--- a/src/xAI.Tests/ChatClientTests.cs
+++ b/src/xAI.Tests/ChatClientTests.cs
@@ -706,6 +706,42 @@ public class ChatClientTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task GrokDoesNotAddEmptyContentToToolCallOnlyMessages()
+    {
+        GetCompletionsRequest? capturedRequest = null;
+        var client = new Mock<xAI.Protocol.Chat.ChatClient>(MockBehavior.Strict);
+        client.Setup(x => x.GetCompletionAsync(It.IsAny<GetCompletionsRequest>(), null, null, CancellationToken.None))
+            .Callback<GetCompletionsRequest, Metadata?, DateTime?, CancellationToken>((req, _, _, _) => capturedRequest = req)
+            .Returns(CallHelpers.CreateAsyncUnaryCall(new GetChatCompletionResponse
+            {
+                Outputs =
+                {
+                    new CompletionOutput
+                    {
+                        Message = new CompletionMessage { Content = "Done" }
+                    }
+                }
+            }));
+
+        var grok = new GrokChatClient(client.Object, "grok-4-1-fast-non-reasoning");
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "What's the time?"),
+            // Assistant message with only a tool call and no text content
+            new(ChatRole.Assistant, [new FunctionCallContent("call-789", "get_time")]),
+            new(ChatRole.Tool, [new FunctionResultContent("call-789", "2024-01-01T00:00:00Z")]),
+        };
+
+        await grok.GetResponseAsync(messages);
+
+        Assert.NotNull(capturedRequest);
+        // Every Content item in every message must be non-empty; an empty Content block
+        // causes the API to return StatusCode="InvalidArgument", Detail="Empty content block".
+        Assert.DoesNotContain(capturedRequest.Messages,
+            m => m.Content.Any(c => c.CalculateSize() == 0));
+    }
+
+    [Fact]
     public async Task GrokSendsDataContentAsBase64ImageUrl()
     {
         GetCompletionsRequest? capturedRequest = null;

--- a/src/xAI/GrokChatClient.cs
+++ b/src/xAI/GrokChatClient.cs
@@ -248,10 +248,6 @@ class GrokChatClient : IChatClient
             if (gmsg.Content.Count == 0 && gmsg.ToolCalls.Count == 0)
                 continue;
 
-            // If we have only tool calls and no content, the gRPC enpoint fails, so add an empty one.
-            if (gmsg.Content.Count == 0)
-                gmsg.Content.Add(new Content());
-
             request.Messages.Add(gmsg);
         }
 


### PR DESCRIPTION
## Fix: Empty content block error on tool-call messages

### Root cause

`MapToRequest` contained a workaround (added when the API was first
integrated) that padded any assistant message containing tool calls but
no text content with a synthetic empty `Content` block:

```
Status(StatusCode="InvalidArgument", Detail="Empty content block")

Grpc.Core.RpcException: Status(StatusCode="InvalidArgument", Detail="Empty content block") at xAI.GrokChatClient.GetResponseAsync(IEnumerable1 messages, ChatOptions options, CancellationToken cancellationToken) in /_/src/xAI/GrokChatClient.cs:line 40 at Microsoft.Extensions.AI.FunctionInvokingChatClient.GetResponseAsync(IEnumerable1 messages, ChatOptions options, CancellationToken cancellationToken) at Microsoft.Agents.AI.ChatClientAgent.RunCoreAsync(IEnumerable1 messages, AgentSession session, AgentRunOptions options, CancellationToken cancellationToken) at Microsoft.Agents.AI.ChatClientAgent.RunCoreAsync(IEnumerable1 messages, AgentSession session, AgentRunOptions options, CancellationToken cancellationToken) at 
```


The xAI gRPC API has since changed its validation: it now **rejects**
messages that contain an empty content block, returning:



This surfaces whenever the model performs a function/tool call, because
the subsequent round-trip includes an assistant message whose `Contents`
contains only `FunctionCallContent` items and no text.

### Fix

Remove the padding block entirely. Assistant messages with only tool
calls are sent with an empty `Content` collection, which the API now
accepts without error.

### Test

`GrokDoesNotAddEmptyContentToToolCallOnlyMessages` — a unit test (no
API key required) that drives a conversation containing a tool-call-only
assistant turn through `MapToRequest` via a mocked `ChatClient` and
asserts that no message in the outgoing request contains a zero-size
`Content` entry.