### PR TITLE
xAI: Add inline data and URL support to FileContent

### DIFF
--- a/.netconfig
+++ b/.netconfig
@@ -152,8 +152,8 @@
 	weak
 [file "src/xAI.Protocol/chat.proto"]
 	url = https://github.com/xai-org/xai-proto/blob/main/proto/xai/api/v1/chat.proto
-	sha = 6473565631bba0e29fbc11dfb3a66a98dd72d496
-	etag = 881e524631d7e6d7a7244f34bf8d99ad0c3dc149146c3a89d0bb626586f99c7f
+	sha = e0c743ba0dcd0a7f9b71a4a0d846c6ff3a9b7e4a
+	etag = 8656b4676c39de9d83c9dd8d102e3fce04df98f940536166baf41f893ba56f5d
 	weak
 [file "src/xAI.Protocol/deferred.proto"]
 	url = https://github.com/xai-org/xai-proto/blob/main/proto/xai/api/v1/deferred.proto
@@ -222,8 +222,8 @@
 	weak
 [file "oss.cs"]
 	url = https://github.com/devlooped/oss/blob/main/oss.cs
-	sha = 9c2f8c729d7cd3dd052b5a09d12fb1f3926247e5
-	etag = e195cacdb0c6ea7ca768514ec94f8595d008c7f5aae805b39beec330895045e3
+	sha = c8c6644c8f0e6ca938eae48b2dcd49084a7a8c09
+	etag = 10312a2096542c1214389009e24a40c989f869c5f2fd77a8294f12276c82cfb7
 	weak
 [file "readme.tmp.md"]
 	url = https://github.com/devlooped/oss/blob/main/readme.tmp.md

--- a/oss.cs
+++ b/oss.cs
@@ -8,8 +8,7 @@ using System.IO;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using CliWrap;
-using Spectre.Console;
+using System.Xml.Linq;
 
 string dotnet = Path.GetFullPath(
     Path.Combine(RuntimeEnvironment.GetRuntimeDirectory(), "..", "..", "..",
@@ -40,10 +39,34 @@ AnsiConsole.WriteLine();
 
 await RunDotNet("file init https://github.com/devlooped/oss/blob/main/.netconfig", "Initializing dotnet file sync from devlooped/oss");
 await RunDotNet($"new classlib -n {projectName} -o src/{projectName} -f net10.0", $"Creating class library src/{projectName}");
+File.Delete($"src/{projectName}/Class1.cs");
 await RunDotNet($"new xunit -n Tests -o src/Tests -f net10.0", "Creating xUnit test project src/Tests");
+File.Delete($"src/Tests/UnitTest1.cs");
 await RunDotNet($"add src/Tests/Tests.csproj reference src/{projectName}/{projectName}.csproj", $"Adding reference from Tests to {projectName}");
+
+var doc = XDocument.Load($"src/{projectName}/{projectName}.csproj", LoadOptions.None);
+doc.Root?.Element("PropertyGroup")?.Element("ImplicitUsings")?.Remove();
+doc.Root?.Element("PropertyGroup")?.Element("Nullable")?.Remove();
+doc.Root?.Element("PropertyGroup")?.Add(new XElement("PackageId", packageId));
+doc.Save($"src/{projectName}/{projectName}.csproj");
+
+doc = XDocument.Load($"src/Tests/Tests.csproj", LoadOptions.None);
+doc.Root?.Element("PropertyGroup")?.Element("ImplicitUsings")?.Remove();
+doc.Root?.Element("PropertyGroup")?.Element("Nullable")?.Remove();
+doc.Root?.Element("PropertyGroup")?.Element("IsPackable")?.Remove();
+doc.Save($"src/Tests/Tests.csproj");
+
+File.WriteAllText($"src/Directory.props",
+    """
+    <Project>
+      <PropertyGroup>
+        <ImplicitUsings>true</ImplicitUsings>
+      </PropertyGroup>
+    </Project>
+    """);
+
 await RunDotNet($"new solution -n {projectName}", $"Creating solution {projectName}.slnx");
-await RunDotNet($"sln {projectName}.slnx add src/{projectName}/{projectName}.csproj src/Tests/Tests.csproj", $"Adding projects to {projectName}.slnx");
+await RunDotNet($"sln {projectName}.slnx add --in-root src/{projectName}/{projectName}.csproj src/Tests/Tests.csproj", $"Adding projects to {projectName}.slnx");
 
 await AnsiConsole.Status()
     .Spinner(Spinner.Known.Dots)

--- a/readme.md
+++ b/readme.md
@@ -419,6 +419,7 @@ Uses your own API Key.
 <!-- sponsors.md -->
 [![Clarius Org](https://avatars.githubusercontent.com/u/71888636?v=4&s=39 "Clarius Org")](https://github.com/clarius)
 [![MFB Technologies, Inc.](https://avatars.githubusercontent.com/u/87181630?v=4&s=39 "MFB Technologies, Inc.")](https://github.com/MFB-Technologies-Inc)
+[![Khamza Davletov](https://avatars.githubusercontent.com/u/13615108?u=11b0038e255cdf9d1940fbb9ae9d1d57115697ab&v=4&s=39 "Khamza Davletov")](https://github.com/khamza85)
 [![SandRock](https://avatars.githubusercontent.com/u/321868?u=99e50a714276c43ae820632f1da88cb71632ec97&v=4&s=39 "SandRock")](https://github.com/sandrock)
 [![DRIVE.NET, Inc.](https://avatars.githubusercontent.com/u/15047123?v=4&s=39 "DRIVE.NET, Inc.")](https://github.com/drivenet)
 [![Keith Pickford](https://avatars.githubusercontent.com/u/16598898?u=64416b80caf7092a885f60bb31612270bffc9598&v=4&s=39 "Keith Pickford")](https://github.com/Keflon)

--- a/readme.tmp.md
+++ b/readme.tmp.md
@@ -28,6 +28,7 @@ OSMF tier. A single fee covers all of [Devlooped packages](https://www.nuget.org
 <!-- sponsors.md -->
 [![Clarius Org](https://avatars.githubusercontent.com/u/71888636?v=4&s=39 "Clarius Org")](https://github.com/clarius)
 [![MFB Technologies, Inc.](https://avatars.githubusercontent.com/u/87181630?v=4&s=39 "MFB Technologies, Inc.")](https://github.com/MFB-Technologies-Inc)
+[![Khamza Davletov](https://avatars.githubusercontent.com/u/13615108?u=11b0038e255cdf9d1940fbb9ae9d1d57115697ab&v=4&s=39 "Khamza Davletov")](https://github.com/khamza85)
 [![SandRock](https://avatars.githubusercontent.com/u/321868?u=99e50a714276c43ae820632f1da88cb71632ec97&v=4&s=39 "SandRock")](https://github.com/sandrock)
 [![DRIVE.NET, Inc.](https://avatars.githubusercontent.com/u/15047123?v=4&s=39 "DRIVE.NET, Inc.")](https://github.com/drivenet)
 [![Keith Pickford](https://avatars.githubusercontent.com/u/16598898?u=64416b80caf7092a885f60bb31612270bffc9598&v=4&s=39 "Keith Pickford")](https://github.com/Keflon)

--- a/src/xAI.Protocol/chat.proto
+++ b/src/xAI.Protocol/chat.proto
@@ -447,9 +447,36 @@ message Content {
 
 // A file attachment in a message.
 message FileContent {
-  // The file ID returned by the Files API when a user uploads a file.
-  // This ID is used to reference the uploaded file in chat conversations.
+  // The file ID from the Files API.
+  //
+  // When set, the file content will be fetched via the Files API.
   string file_id = 1;
+
+  // Inline file bytes (optional).
+  //
+  // When set, the file content is provided directly in the chat request and does
+  // NOT require uploading to the Files API first.
+  //
+  // Exactly one of `file_id`, `data`, or `url` SHOULD be set.
+  bytes data = 2;
+
+  // Filename for inline uploads.
+  //
+  // Recommended when `data` is set. Used for display and may be used by
+  // downstream systems to infer file type.
+  string filename = 3;
+
+  // Optional MIME type for inline uploads (e.g. "application/pdf").
+  //
+  // If unset, downstream systems may attempt to infer the MIME type from the
+  // content and/or filename.
+  string mime_type = 4;
+
+  // Public URL to a file attachment.
+  //
+  // When set, the file will be fetched from this URL as an attachment.
+  // Exactly one of `file_id`, `data`, or `url` SHOULD be set.
+  string url = 5;
 }
 
 enum IncludeOption {


### PR DESCRIPTION
# xai-org/xai-proto

- Add inline data and URL support to FileContent (#43) https://github.com/xai-org/xai-proto/commit/e0c743b

# devlooped/oss

- Enable ImplicitUsings via Directory.props https://github.com/devlooped/oss/commit/c8c6644
