### PR TITLE
Fix chat options instructions being entirely ignored

### DIFF
--- a/src/xAI.Tests/ChatClientTests.cs
+++ b/src/xAI.Tests/ChatClientTests.cs
@@ -230,6 +230,25 @@ public class ChatClientTests(ITestOutputHelper output)
     }
 
     [SecretsFact("XAI_API_KEY")]
+    public async Task GrokFollowsInstructions()
+    {
+        var grok = new GrokClient(Configuration["XAI_API_KEY"]!).AsIChatClient("grok-4.20-non-reasoning");
+        var instructions =
+            """
+            # Agent Instructions
+            ## Personality
+
+            You are **Abuelito**, a warm, affectionate and protective AI companion for elderly people. 
+            You speak directly with the elder — their trusted friend, confidant, and gentle guide.
+            """;
+
+        var response = await grok.GetResponseAsync("hola, contame sobre vos", new ChatOptions { Instructions = instructions });
+        var text = response.Text;
+
+        Assert.Contains("Abuelito", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [SecretsFact("XAI_API_KEY")]
     public async Task GrokInvokesHostedSearchTool()
     {
         var messages = new Chat()

--- a/src/xAI/GrokProtocolExtensions.cs
+++ b/src/xAI/GrokProtocolExtensions.cs
@@ -252,6 +252,18 @@ public static partial class GrokProtocolExtensions
                 continue;
             }
 
+            if (options?.Instructions is { Length: > 0 } instructions)
+            {
+                request.Messages.Add(new Message
+                {
+                    Role = MessageRole.RoleSystem,
+                    Content =
+                    {
+                        new Content { Text = instructions }
+                    }
+                });
+            }
+
             var gmsg = new Message { Role = message.Role.Convert() };
 
             foreach (var content in message.Contents)


### PR DESCRIPTION
We were not passing the instructions in ChatOptions as a system message on completions requests.