### PR TITLE
Fix ChatOptions.Instructions ignored in completions requests

### DIFF
--- a/src/xAI.Tests/ChatClientTests.cs
+++ b/src/xAI.Tests/ChatClientTests.cs
@@ -230,6 +230,25 @@ public class ChatClientTests(ITestOutputHelper output)
     }
 
     [SecretsFact("XAI_API_KEY")]
+    public async Task GrokFollowsInstructions()
+    {
+        var grok = new GrokClient(Configuration["XAI_API_KEY"]!).AsIChatClient("grok-4.20-non-reasoning");
+        var instructions =
+            """
+            # Agent Instructions
+            ## Personality
+
+            You are **Abuelito**, a warm, affectionate and protective AI companion for elderly people. 
+            You speak directly with the elder — their trusted friend, confidant, and gentle guide.
+            """;
+
+        var response = await grok.GetResponseAsync("hola, contame sobre vos", new ChatOptions { Instructions = instructions });
+        var text = response.Text;
+
+        Assert.Contains("Abuelito", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [SecretsFact("XAI_API_KEY")]
     public async Task GrokInvokesHostedSearchTool()
     {
         var messages = new Chat()

--- a/src/xAI.Tests/ChatClientTests.cs
+++ b/src/xAI.Tests/ChatClientTests.cs
@@ -229,23 +229,38 @@ public class ChatClientTests(ITestOutputHelper output)
         Assert.Contains("SpaceX", text);
     }
 
-    [SecretsFact("XAI_API_KEY")]
-    public async Task GrokFollowsInstructions()
+    [Fact]
+    public async Task GrokSendsInstructionsAsLeadingSystemMessage()
     {
-        var grok = new GrokClient(Configuration["XAI_API_KEY"]!).AsIChatClient("grok-4.20-non-reasoning");
-        var instructions =
-            """
-            # Agent Instructions
-            ## Personality
+        GetCompletionsRequest? capturedRequest = null;
+        var client = new Mock<xAI.Protocol.Chat.ChatClient>(MockBehavior.Strict);
+        client.Setup(x => x.GetCompletionAsync(It.IsAny<GetCompletionsRequest>(), null, null, CancellationToken.None))
+            .Callback<GetCompletionsRequest, Metadata?, DateTime?, CancellationToken>((req, _, _, _) => capturedRequest = req)
+            .Returns(CallHelpers.CreateAsyncUnaryCall(new GetChatCompletionResponse
+            {
+                Outputs =
+                {
+                    new CompletionOutput
+                    {
+                        Message = new CompletionMessage { Content = "Hello!" }
+                    }
+                }
+            }));
 
-            You are **Abuelito**, a warm, affectionate and protective AI companion for elderly people. 
-            You speak directly with the elder — their trusted friend, confidant, and gentle guide.
-            """;
+        var instructions = "You are a helpful assistant.";
+        var grok = new GrokChatClient(client.Object, "grok-4-1-fast-non-reasoning");
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Hello"),
+        };
 
-        var response = await grok.GetResponseAsync("hola, contame sobre vos", new ChatOptions { Instructions = instructions });
-        var text = response.Text;
+        await grok.GetResponseAsync(messages, new ChatOptions { Instructions = instructions });
 
-        Assert.Contains("Abuelito", text, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(capturedRequest);
+        var firstMessage = capturedRequest.Messages.FirstOrDefault();
+        Assert.NotNull(firstMessage);
+        Assert.Equal(MessageRole.RoleSystem, firstMessage.Role);
+        Assert.Equal(instructions, firstMessage.Content[0].Text);
     }
 
     [SecretsFact("XAI_API_KEY")]

--- a/src/xAI/GrokProtocolExtensions.cs
+++ b/src/xAI/GrokProtocolExtensions.cs
@@ -238,6 +238,14 @@ public static partial class GrokProtocolExtensions
         if (options?.TopP is { } topP) request.TopP = topP;
         if (options?.FrequencyPenalty is { } frequencyPenalty) request.FrequencyPenalty = frequencyPenalty;
         if (options?.PresencePenalty is { } presencePenalty) request.PresencePenalty = presencePenalty;
+        if (options?.Instructions is { Length: > 0 } instructions)
+        {
+            request.Messages.Insert(0, new Message
+            {
+                Role = MessageRole.RoleSystem,
+                Content = { new Content { Text = instructions } }
+            });
+        }
 
         foreach (var message in messages)
         {


### PR DESCRIPTION
`ChatOptions.Instructions` was never forwarded to the gRPC `GetCompletionsRequest`, so system-level instructions were silently dropped on every call.

## Changes

- **`GrokProtocolExtensions.cs`**: When `ChatOptions.Instructions` is set, prepend it as a `RoleSystem` message at index 0 of `request.Messages`, ensuring it precedes any user/assistant messages regardless of `RawRepresentationFactory` output.
- **`ChatClientTests.cs`**: Replace flaky prompt-compliance integration test with a deterministic unit test that mocks the gRPC client, captures the outbound `GetCompletionsRequest`, and asserts the instruction appears as the leading system message.

```csharp
if (options?.Instructions is { Length: > 0 } instructions)
{
    request.Messages.Insert(0, new Message
    {
        Role = MessageRole.RoleSystem,
        Content = { new Content { Text = instructions } }
    });
}
```