### PR TITLE
Add Files gRPC service proto and sync usage.proto

### DIFF
--- a/.github/workflows/dotnet-env.yml
+++ b/.github/workflows/dotnet-env.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   which-dotnet:
     runs-on: ubuntu-latest 
+    env:
+      PR_TOKEN: ${{ secrets.DEVLOOPED_TOKEN || secrets.GH_TOKEN }}
     permissions:
       contents: write
       pull-requests: write
@@ -20,18 +22,19 @@ jobs:
         with:
           name: ${{ secrets.BOT_NAME }}
           email: ${{ secrets.BOT_EMAIL }}
-          gh_token: ${{ secrets.GH_TOKEN }}
+          gh_token: ${{ env.PR_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🤘 checkout
         uses: actions/checkout@v4
         with: 
-          token: ${{ env.GH_TOKEN }}
+          token: ${{ env.PR_TOKEN || github.token }}
 
       - name: 🤌 dotnet
         uses: devlooped/actions-which-dotnet@v1
 
       - name: ✍ pull request
+        if: env.PR_TOKEN != ''
         uses: peter-evans/create-pull-request@v7
         with:
           base: main
@@ -41,4 +44,9 @@ jobs:
           title: "⚙ Update dotnet versions"
           body: "Update dotnet versions"
           commit-message: "Update dotnet versions"
-          token: ${{ env.GH_TOKEN }}          
+          token: ${{ env.PR_TOKEN }}
+
+      - name: ⚠️ skip pull request
+        if: env.PR_TOKEN == ''
+        shell: bash
+        run: echo "::warning::Skipping PR creation because neither DEVLOOPED_TOKEN nor GH_TOKEN is configured. GITHUB_TOKEN cannot create pull requests in this repository."

--- a/.github/workflows/includes.yml
+++ b/.github/workflows/includes.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   includes:
     runs-on: ubuntu-latest
+    env:
+      PR_TOKEN: ${{ secrets.DEVLOOPED_TOKEN || secrets.GH_TOKEN }}
     permissions:
       contents: write
       pull-requests: write
@@ -21,13 +23,13 @@ jobs:
         with:
           name: ${{ secrets.BOT_NAME }}
           email: ${{ secrets.BOT_EMAIL }}
-          gh_token: ${{ secrets.GH_TOKEN }}
+          gh_token: ${{ env.PR_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🤘 checkout
         uses: actions/checkout@v4
         with: 
-          token: ${{ env.GH_TOKEN }}
+          token: ${{ env.PR_TOKEN || github.token }}
 
       - name: +Mᐁ includes
         uses: devlooped/actions-includes@v1
@@ -50,6 +52,7 @@ jobs:
           ((get-content -raw $file) -replace '\$product\$',$product).trim() | set-content $file
 
       - name: ✍ pull request
+        if: env.PR_TOKEN != ''
         uses: peter-evans/create-pull-request@v8
         with:
           add-paths: |
@@ -64,4 +67,9 @@ jobs:
           commit-message: +Mᐁ includes
           title: +Mᐁ includes
           body: +Mᐁ includes
-          token: ${{ env.GH_TOKEN }}
+          token: ${{ env.PR_TOKEN }}
+
+      - name: ⚠️ skip pull request
+        if: env.PR_TOKEN == ''
+        shell: bash
+        run: echo "::warning::Skipping PR creation because neither DEVLOOPED_TOKEN nor GH_TOKEN is configured. GITHUB_TOKEN cannot create pull requests in this repository."

--- a/.netconfig
+++ b/.netconfig
@@ -56,7 +56,7 @@
 [file ".github/workflows/dotnet-env.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-env.yml
 	sha = 77e83f238196d2723640abef0c7b6f43994f9747
-	etag = fcb9759a96966df40dcd24906fd328ddec05953b7e747a6bb8d0d1e4c3865274
+	etag = 68c1e28f475ff9d05f985bf53a51fce6e64b24a8b75bd8e47119ff57309281f1
 	weak
 [file ".github/workflows/dotnet-file.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file.yml
@@ -66,7 +66,7 @@
 [file ".github/workflows/includes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/includes.yml
 	sha = 06628725a6303bb8c4cf3076a384fc982a91bc0b
-	etag = 478f91d4126230e57cc601382da1ba23f9daa054645b4af89800d8dd862e64fd
+	etag = 5e6a10be141ee629201bfad01eae09b5c36a67f541ec7ab411ae400b5d73de1d
 	weak
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
@@ -193,7 +193,7 @@
 [file "src/xAI.Protocol/usage.proto"]
 	url = https://github.com/xai-org/xai-proto/blob/main/proto/xai/api/v1/usage.proto
 	sha = 362749661fa2d340d234ad372fab920538897821
-	etag = bd66823dfde1a2fff714d3712104bef886baf22da9f94c7505acee37d3ff67fd
+	etag = 9fcf9731a547857d554e968968aedc3016fc5210e0a45d5b59d75a03b816a81e
 	weak
 [file "src/xAI.Protocol/video.proto"]
 	url = https://github.com/xai-org/xai-proto/blob/main/proto/xai/api/v1/video.proto
@@ -230,4 +230,8 @@
 	url = https://github.com/devlooped/oss/blob/main/.github/copilot-instructions.md
 	sha = e616d89d9537c4b8ccf1c20dd277ab82104167c4
 	etag = 6ee650d118a57494d3545d54718ccaa5257b09d54504e9c21514fe596edd9678
+	weak
+[file "src/xAI.Protocol/files.proto"]
+	url = https://github.com/xai-org/xai-proto/blob/main/proto/xai/api/v1/files.proto
+	etag = 4c91f851b288a225acfc1173f2f8853a1b550da1e97d2fdcec99debb5f8fac43
 	weak

--- a/src/xAI.Protocol/files.proto
+++ b/src/xAI.Protocol/files.proto
@@ -1,0 +1,180 @@
+syntax = "proto3";
+
+package xai_api;
+
+import "google/protobuf/timestamp.proto";
+
+// Service for uploading, listing, retrieving, and deleting files.
+//
+// Files are referenced by the `id` returned on upload (e.g. when attaching
+// to chat completions). Maximum file size is 512 MB.
+service Files {
+  // Upload a file. The first stream message MUST set `chunk = init`
+  // (filename + optional TTL); subsequent messages MUST set `chunk = data`
+  // with file bytes in order. Recommended chunk size up to 5 MB; total
+  // size capped at 512 MB. Returns the new file's metadata.
+  //
+  // Errors: INVALID_ARGUMENT (missing/misplaced init, bad filename, bad
+  // TTL), RESOURCE_EXHAUSTED (over 512 MB).
+  rpc UploadFile(stream UploadFileChunk) returns (File) {}
+
+  // List file metadata, paginated and sorted. Returns metadata only — use
+  // `RetrieveFileContent` to download bytes.
+  rpc ListFiles(ListFilesRequest) returns (ListFilesResponse) {}
+
+  // Get metadata for one file. Returns metadata only — use
+  // `RetrieveFileContent` to download bytes. Errors NOT_FOUND if no
+  // accessible file with that id (including already-deleted).
+  rpc RetrieveFile(RetrieveFileRequest) returns (File) {}
+
+  // Delete a file. After success it stops appearing in `ListFiles` /
+  // `RetrieveFile` and is no longer downloadable. Errors NOT_FOUND if no
+  // accessible file with that id (including already-deleted).
+  rpc DeleteFile(DeleteFileRequest) returns (DeleteFileResponse) {}
+
+  // Stream the file's contents in chunks of up to 5 MB, in order.
+  // Concatenate `data` from every chunk to reconstruct the file.
+  rpc RetrieveFileContent(RetrieveFileContentRequest) returns (stream FileContentChunk) {}
+}
+
+// First stream message of an `UploadFile` call. Sent exactly once, before
+// any data chunks.
+message UploadFileInit {
+  // Filename (max 255 Unicode chars). Must not contain ASCII control
+  // chars, line terminators (CR/LF/NEL/U+2028/U+2029), null bytes, `"`,
+  // `;`, or `\` — these would break `Content-Disposition` headers.
+  string name = 1;
+
+  // Optional TTL in seconds, measured from upload time. Must be in
+  // [3600, 2592000] (1h to 30d) inclusive — 0 and out-of-range values are
+  // rejected. Unset means no expiration.
+  optional int64 expires_after = 2;
+}
+
+// One message in an `UploadFile` stream: either `init` (required first) or
+// a `data` chunk.
+message UploadFileChunk {
+  oneof chunk {
+    // Information about the file being uploaded.
+    UploadFileInit init = 1;
+    // Up to ~5 MB per chunk recommended; cumulative size capped at 512 MB.
+    bytes data = 2;
+  }
+}
+
+// Metadata for an uploaded file.
+message File {
+  // Size in bytes.
+  int64 size = 1;
+
+  // UTC timestamp the file was uploaded.
+  google.protobuf.Timestamp created_at = 2;
+
+  // UTC timestamp the file will be auto-deleted at. Present only if the
+  // upload set `UploadFileInit.expires_after`.
+  optional google.protobuf.Timestamp expires_at = 3;
+
+  // Filename as supplied at upload.
+  string filename = 4;
+
+  // Opaque server-assigned ID (e.g. `file_<uuid>`). Use this in
+  // `RetrieveFile`, `DeleteFile`, `RetrieveFileContent`, and other xAI
+  // APIs that accept a file reference.
+  string id = 5;
+
+  reserved 6;
+}
+
+// Sort direction for list-style RPCs.
+enum Ordering {
+  ASCENDING = 0;
+  DESCENDING = 1;
+}
+
+// Field to sort `ListFiles` results by.
+enum FilesSortBy {
+  // Default.
+  FILES_SORT_BY_CREATED_AT = 0;
+  // Case-sensitive lexicographic order.
+  FILES_SORT_BY_FILENAME = 1;
+  FILES_SORT_BY_SIZE = 2;
+}
+
+// Request message for `Files.ListFiles`.
+message ListFilesRequest {
+  // Page size, in [1, 100]. Values <= 0 default to 100; values > 100 are
+  // clamped.
+  int32 limit = 1;
+
+  // Sort direction. Defaults to ASCENDING.
+  Ordering order = 2;
+
+  // Opaque token from a prior `ListFilesResponse.pagination_token`, used to
+  // resume listing where the previous page left off. Omit on the first
+  // call. Use the same `order` and `sort_by` as the request that produced
+  // the token; otherwise paging behavior is undefined. Treat as opaque;
+  // format may change.
+  optional string pagination_token = 3;
+
+  // Sort field. Defaults to `FILES_SORT_BY_CREATED_AT`.
+  optional FilesSortBy sort_by = 4;
+}
+
+// Response message for `Files.ListFiles`.
+message ListFilesResponse {
+  // List of file metadata.
+  repeated File data = 1;
+
+  // Token for the next page; absent on the final page.
+  optional string pagination_token = 2;
+}
+
+// Request message for `Files.RetrieveFile`.
+message RetrieveFileRequest {
+  // The ID of the file to use for this request.
+  string file_id = 1;
+}
+
+// Request message for `Files.DeleteFile`.
+message DeleteFileRequest {
+  // The ID of the file to use for this request.
+  string file_id = 1;
+}
+
+// Response message for `Files.DeleteFile`.
+message DeleteFileResponse {
+  // Echoes the deleted file's id.
+  string id = 1;
+
+  // Always true on success (failures surface as gRPC errors).
+  bool deleted = 2;
+}
+
+// Which representation of a file to download.
+enum DownloadFormat {
+  // Treated as `DOWNLOAD_FORMAT_ORIGINAL` (the default when `format` is
+  // unset).
+  DOWNLOAD_FORMAT_UNKNOWN = 0;
+  // Raw bytes as uploaded.
+  DOWNLOAD_FORMAT_ORIGINAL = 1;
+  // Text extracted from the file (e.g. PDF/DOCX). Only works for file
+  // types with a server-side text-extraction pass; fails otherwise.
+  DOWNLOAD_FORMAT_TEXT = 2;
+}
+
+// Request message for `Files.RetrieveFileContent`.
+message RetrieveFileContentRequest {
+  // The ID of the file to download.
+  string file_id = 1;
+
+  // Format of the downloaded content.
+  // ORIGINAL: raw file bytes (default).
+  // TEXT: extracted/converted text content.
+  optional DownloadFormat format = 2;
+}
+
+// One chunk of a `RetrieveFileContent` stream.
+message FileContentChunk {
+  // Up to 5 MB of file bytes. Final/intermediate chunks may be smaller.
+  bytes data = 1;
+}

--- a/src/xAI.Protocol/usage.proto
+++ b/src/xAI.Protocol/usage.proto
@@ -1,5 +1,4 @@
 syntax = "proto3";
-option csharp_namespace = "xAI.Protocol";
 
 package xai_api;
 
@@ -28,14 +27,22 @@ message SamplingUsage {
   // Total number of image tokens in the prompt.
   int32 prompt_image_tokens = 5;
 
-  // Number of individual live search sources used.
-  // Only applicable when live search is enabled.
-  // e.g. If a live search query returns citations from both X and Web and news sources, this will be 3.
-  // If it returns citations from only X, this will be 1.
+  // [DEPRECATED - live search feature has been deprecated so this field is
+  // redundant] Number of individual live search sources used. Only applicable
+  // when live search is enabled. e.g. If a live search query returns citations
+  // from both X and Web and news sources, this will be 3. If it returns
+  // citations from only X, this will be 1.
   int32 num_sources_used = 8;
 
   // List of server side tools called.
   repeated ServerSideTool server_side_tools_used = 9;
+
+  // Full price paid by the user for this request, in USD ticks.
+  // For requests with server-side tools, this is the sum of token cost and
+  // server-side tool cost. Also used for image gen, video gen, etc.
+  // 1 USD = 10,000,000,000 ticks (i.e. 1 tick = 1e-10 USD).
+  // To convert to dollars, divide by 10,000,000,000.
+  optional int64 cost_in_usd_ticks = 11;
 }
 
 // Usage of embedding models.

--- a/src/xAI.Tests/ChatClientTests.cs
+++ b/src/xAI.Tests/ChatClientTests.cs
@@ -8,6 +8,7 @@ using Tests.Client.Helpers;
 using xAI.Protocol;
 using static ConfigurationExtensions;
 using Chat = Devlooped.Extensions.AI.Chat;
+using File = System.IO.File;
 
 namespace xAI.Tests;
 


### PR DESCRIPTION
## Changes

### New: `src/xAI.Protocol/files.proto`
Adds the `Files` gRPC service for managing uploaded files:
- `UploadFile` (client streaming): upload in chunks up to 5 MB; 512 MB total cap; first message must be `init` with filename and optional TTL
- `ListFiles`: paginated listing, sortable by created date, filename, or size
- `RetrieveFile`: fetch file metadata by ID
- `DeleteFile`: delete a file by ID
- `RetrieveFileContent` (server streaming): download raw bytes or extracted text in up to 5 MB chunks

### Updated: `src/xAI.Protocol/usage.proto`
- Removed `csharp_namespace` option (synced from upstream)
- Marked `num_sources_used` as deprecated (live search feature deprecated upstream)
- Added `cost_in_usd_ticks` (optional `int64`): full price paid in USD ticks; 1 USD = 10,000,000,000 ticks

### Updated: CI Workflows (`.github/workflows/dotnet-env.yml`, `includes.yml`)
- Replaced hard-coded `GH_TOKEN` references with `DEVLOOPED_TOKEN || GH_TOKEN` via a `PR_TOKEN` job-level env var
- Added conditional `✍ pull request` step guard (`if: env.PR_TOKEN != ''`)
- Added `⚠️ skip pull request` warning step when neither token is configured

### Updated: `src/xAI.Tests/ChatClientTests.cs`
- Added `using File = System.IO.File;` alias to resolve ambiguity with the new `File` proto message type