### PR TITLE
Fix streaming usage accounting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,4 @@
 - `AsISpeechToTextClient` returns an `ISpeechToTextClient` implementation that uses `POST /v1/stt` for file transcription and `wss://.../v1/stt` for raw-audio streaming transcription.
 - TTS defaults follow xAI docs: voice `eve`, language `en` when omitted by `TextToSpeechOptions`, and MP3 output when no codec is specified.
 - STT streaming defaults follow xAI docs: encoding `pcm` and sample rate `16000` when omitted; WebSocket input must be raw encoded audio, not MP3/WAV container bytes.
+- Chat streaming `GetChatCompletionChunk.Usage` values are cumulative within a sampling segment and may reset across tool-driven segments; emit deltas (or restart deltas after a reset) so `ToChatResponse()` totals match non-streaming usage.

--- a/src/xAI.Tests/ChatClientTests.cs
+++ b/src/xAI.Tests/ChatClientTests.cs
@@ -671,6 +671,159 @@ public class ChatClientTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task GrokStreamingResponseUsesUsageDeltas()
+    {
+        var client = new Mock<xAI.Protocol.Chat.ChatClient>(MockBehavior.Strict);
+        client.Setup(x => x.GetCompletionChunk(It.IsAny<GetCompletionsRequest>(), null, null, CancellationToken.None))
+            .Returns(CallHelpers.CreateAsyncServerStreamingCall(
+                new GetChatCompletionChunk
+                {
+                    Id = "response-1",
+                    Model = "grok-4-1-fast-non-reasoning",
+                    Outputs =
+                    {
+                        new CompletionOutputChunk
+                        {
+                            Delta = new Delta
+                            {
+                                Role = MessageRole.RoleAssistant,
+                                Content = "Hello"
+                            },
+                            FinishReason = FinishReason.ReasonInvalid,
+                            Index = 0
+                        }
+                    },
+                    Usage = new SamplingUsage
+                    {
+                        PromptTokens = 10,
+                        CompletionTokens = 2,
+                        TotalTokens = 12
+                    }
+                },
+                new GetChatCompletionChunk
+                {
+                    Id = "response-1",
+                    Model = "grok-4-1-fast-non-reasoning",
+                    Outputs =
+                    {
+                        new CompletionOutputChunk
+                        {
+                            Delta = new Delta
+                            {
+                                Content = " world"
+                            },
+                            FinishReason = FinishReason.ReasonStop,
+                            Index = 0
+                        }
+                    },
+                    Usage = new SamplingUsage
+                    {
+                        PromptTokens = 10,
+                        CompletionTokens = 4,
+                        TotalTokens = 14
+                    }
+                }));
+
+        var grok = new GrokChatClient(client.Object, "grok-4-1-fast-non-reasoning");
+
+        var updates = await grok.GetStreamingResponseAsync("Hi").ToListAsync();
+        var response = updates.ToChatResponse();
+
+        Assert.NotNull(response.Usage);
+        Assert.Equal(10, response.Usage.InputTokenCount);
+        Assert.Equal(4, response.Usage.OutputTokenCount);
+        Assert.Equal(14, response.Usage.TotalTokenCount);
+    }
+
+    [Fact]
+    public async Task GrokStreamingResponseUsageHandlesCounterResets()
+    {
+        var client = new Mock<xAI.Protocol.Chat.ChatClient>(MockBehavior.Strict);
+        client.Setup(x => x.GetCompletionChunk(It.IsAny<GetCompletionsRequest>(), null, null, CancellationToken.None))
+            .Returns(CallHelpers.CreateAsyncServerStreamingCall(
+                new GetChatCompletionChunk
+                {
+                    Id = "response-2",
+                    Model = "grok-4-1-fast-non-reasoning",
+                    Outputs =
+                    {
+                        new CompletionOutputChunk
+                        {
+                            Delta = new Delta
+                            {
+                                Role = MessageRole.RoleAssistant,
+                                Content = "Phase one"
+                            },
+                            FinishReason = FinishReason.ReasonInvalid,
+                            Index = 0
+                        }
+                    },
+                    Usage = new SamplingUsage
+                    {
+                        PromptTokens = 10,
+                        CompletionTokens = 2,
+                        TotalTokens = 12
+                    }
+                },
+                new GetChatCompletionChunk
+                {
+                    Id = "response-2",
+                    Model = "grok-4-1-fast-non-reasoning",
+                    Outputs =
+                    {
+                        new CompletionOutputChunk
+                        {
+                            Delta = new Delta
+                            {
+                                Content = " complete"
+                            },
+                            FinishReason = FinishReason.ReasonInvalid,
+                            Index = 0
+                        }
+                    },
+                    Usage = new SamplingUsage
+                    {
+                        PromptTokens = 10,
+                        CompletionTokens = 4,
+                        TotalTokens = 14
+                    }
+                },
+                new GetChatCompletionChunk
+                {
+                    Id = "response-2",
+                    Model = "grok-4-1-fast-non-reasoning",
+                    Outputs =
+                    {
+                        new CompletionOutputChunk
+                        {
+                            Delta = new Delta
+                            {
+                                Content = " phase two"
+                            },
+                            FinishReason = FinishReason.ReasonStop,
+                            Index = 0
+                        }
+                    },
+                    Usage = new SamplingUsage
+                    {
+                        PromptTokens = 3,
+                        CompletionTokens = 3,
+                        TotalTokens = 6
+                    }
+                }));
+
+        var grok = new GrokChatClient(client.Object, "grok-4-1-fast-non-reasoning");
+
+        var updates = await grok.GetStreamingResponseAsync("Hi").ToListAsync();
+        var response = updates.ToChatResponse();
+
+        Assert.NotNull(response.Usage);
+        Assert.Equal(13, response.Usage.InputTokenCount);
+        Assert.Equal(7, response.Usage.OutputTokenCount);
+        Assert.Equal(20, response.Usage.TotalTokenCount);
+    }
+
+    [Fact]
     public async Task AskFiles()
     {
 

--- a/src/xAI.Tests/Extensions/CallHelpers.cs
+++ b/src/xAI.Tests/Extensions/CallHelpers.cs
@@ -42,5 +42,31 @@ namespace Tests.Client.Helpers
                 () => new Metadata(),
                 () => { });
         }
+
+        public static AsyncServerStreamingCall<TResponse> CreateAsyncServerStreamingCall<TResponse>(params TResponse[] responses)
+        {
+            return new AsyncServerStreamingCall<TResponse>(
+                new TestAsyncStreamReader<TResponse>(responses),
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { });
+        }
+
+        class TestAsyncStreamReader<TResponse>(IEnumerable<TResponse> responses) : IAsyncStreamReader<TResponse>
+        {
+            readonly IEnumerator<TResponse> enumerator = responses.GetEnumerator();
+
+            public TResponse Current { get; private set; } = default!;
+
+            public Task<bool> MoveNext(CancellationToken cancellationToken)
+            {
+                if (!enumerator.MoveNext())
+                    return Task.FromResult(false);
+
+                Current = enumerator.Current;
+                return Task.FromResult(true);
+            }
+        }
     }
 }

--- a/src/xAI.Tests/SanityChecks.cs
+++ b/src/xAI.Tests/SanityChecks.cs
@@ -446,6 +446,33 @@ public class SanityChecks(ITestOutputHelper output)
         output.WriteLine($"Code interpreter calls: {codeInterpreterCalls.Count}");
     }
 
+    [SecretsFact("CI_XAI_API_KEY")]
+    public async Task StreamingUsageRoughlyMatchesNonStreamingUsage()
+    {
+        var client = new GrokClient(Configuration["CI_XAI_API_KEY"]!)
+            .AsIChatClient("grok-4-1-fast-non-reasoning");
+
+        var prompts = new[]
+        {
+            """Reply with JSON only: {"number":7}""",
+            """Using the previous assistant response, add 5 and reply with JSON only: {"number":12}""",
+            """Using the latest number from this conversation, multiply it by 3 and reply with JSON only: {"number":36}""",
+        };
+
+        var nonStreamingUsage = await GetConversationUsageAsync(client, prompts, streaming: false);
+        var streamingUsage = await GetConversationUsageAsync(client, prompts, streaming: true);
+        var usageDelta = Math.Abs(streamingUsage - nonStreamingUsage) / (double)nonStreamingUsage;
+
+        output.WriteLine($"Non-streaming total tokens: {nonStreamingUsage}");
+        output.WriteLine($"Streaming total tokens: {streamingUsage}");
+        output.WriteLine($"Relative delta: {usageDelta:P2}");
+
+        Assert.True(nonStreamingUsage > 0, "Expected non-streaming total token usage to be reported.");
+        Assert.True(streamingUsage > 0, "Expected streaming total token usage to be reported.");
+        Assert.True(usageDelta <= 0.20,
+            $"Expected streaming total token usage to remain within 20% of non-streaming usage, but got {streamingUsage} vs {nonStreamingUsage} ({usageDelta:P2}).");
+    }
+
     [SecretsTheory("CI_XAI_API_KEY")]
     [InlineData("rex")]
     public async Task TextToSpeech_SpeechToText(string voiceId)
@@ -519,6 +546,38 @@ public class SanityChecks(ITestOutputHelper output)
 
         var updates = await client.GetStreamingResponseAsync(chat, options).ToListAsync();
         return updates.ToChatResponse();
+    }
+
+    static async Task<long> GetConversationUsageAsync(IChatClient client, IReadOnlyList<string> prompts, bool streaming)
+    {
+        var chat = new ChatConversation
+        {
+            { "system", "You are a precise assistant. Reply with compact JSON only." },
+        };
+
+        long totalTokenCount = 0;
+
+        foreach (var prompt in prompts)
+        {
+            chat.Add("user", prompt);
+
+            var response = await GetResponseAsync(client, chat, new GrokChatOptions
+            {
+                ResponseFormat = ChatResponseFormat.Json,
+                Temperature = 0,
+                MaxOutputTokens = 64,
+            }, streaming);
+
+            Assert.NotNull(response.Usage);
+            Assert.NotNull(response.Usage.TotalTokenCount);
+            var tokenCount = response.Usage.TotalTokenCount.Value;
+            Assert.True(tokenCount > 0, $"Expected token usage for prompt '{prompt}'.");
+
+            totalTokenCount += tokenCount;
+            chat.AddRange(response.Messages);
+        }
+
+        return totalTokenCount;
     }
 
     static T ParseJson<T>(ChatResponse response, ITestOutputHelper output)

--- a/src/xAI/GrokChatClient.cs
+++ b/src/xAI/GrokChatClient.cs
@@ -70,6 +70,9 @@ class GrokChatClient : IGrokChatClient
         {
             var request = this.AsCompletionsRequest(messages, options);
             var call = client.GetCompletionChunk(request, cancellationToken: cancellationToken);
+            var promptTokens = 0;
+            var completionTokens = 0;
+            var totalTokens = 0;
 
             await foreach (var chunk in call.ResponseStream.ReadAllAsync(cancellationToken))
             {
@@ -107,7 +110,7 @@ class GrokChatClient : IGrokChatClient
                     text is not null)
                     update.Contents.Add(new TextContent(text));
 
-                if (chunk.Usage.Convert() is { } usage)
+                if (ConvertStreamingUsageDelta(chunk.Usage, ref promptTokens, ref completionTokens, ref totalTokens) is { } usage)
                     update.Contents.Add(new UsageContent(usage) { RawRepresentation = chunk.Usage });
 
                 yield return update;
@@ -133,6 +136,34 @@ class GrokChatClient : IGrokChatClient
             FileId = file,
             ToolName = "collections_search",
             Url = new Uri($"collections://{collection}/files/{file}"),
+        };
+    }
+
+    static UsageDetails? ConvertStreamingUsageDelta(SamplingUsage usage, ref int promptTokens, ref int completionTokens, ref int totalTokens)
+    {
+        if (usage == null)
+            return null;
+
+        var reset = usage.PromptTokens < promptTokens
+            || usage.CompletionTokens < completionTokens
+            || usage.TotalTokens < totalTokens;
+
+        var inputDelta = reset ? usage.PromptTokens : usage.PromptTokens - promptTokens;
+        var outputDelta = reset ? usage.CompletionTokens : usage.CompletionTokens - completionTokens;
+        var totalDelta = reset ? usage.TotalTokens : usage.TotalTokens - totalTokens;
+
+        promptTokens = usage.PromptTokens;
+        completionTokens = usage.CompletionTokens;
+        totalTokens = usage.TotalTokens;
+
+        if (inputDelta == 0 && outputDelta == 0 && totalDelta == 0)
+            return null;
+
+        return new UsageDetails
+        {
+            InputTokenCount = inputDelta,
+            OutputTokenCount = outputDelta,
+            TotalTokenCount = totalDelta
         };
     }
 


### PR DESCRIPTION
## Summary
- fix streamed chat usage accounting by emitting usage deltas and handling counter resets across tool-driven streaming segments
- add regression tests for streamed usage aggregation and reset handling
- add a live integration test that compares multi-turn streaming and non-streaming usage totals

Closes #142