### PR TITLE
⬆️ Bump files with dotnet-file sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ TestResults
 results
 BenchmarkDotNet.Artifacts
 /app
+/mcps
 .vs
 .vscode
 .genaiscript

--- a/.netconfig
+++ b/.netconfig
@@ -80,8 +80,8 @@
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
-	sha = 12c18e78c4bbab118b798d04344e5a5253216841
-	etag = 09b499201361a59fad0036e925f4008cdd7bdc6723ba37ff18cc509e6024b2bf
+	sha = c1d29fbde52b1505288e3392e7f5fdcb2299f322
+	etag = f502a2be3b4155fd86675ef45a4364e598979738128a612deb7db59074f93a51
 	weak
 [file "Directory.Build.rsp"]
 	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp
@@ -105,13 +105,13 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = dd13ed3334135c30dcb1e3b2295dc7622de298d9
-	etag = b2b90c6d617db9712cc8be2031b767d3ba951015717984f52b4872cc39f93e72
+	sha = 6e2438919e108aeb75106dc0737c45f5e55d5f42
+	etag = f1d6384abf18d8d891ce5e835a10c73fe029c42151374be96d7e4af43d189c65
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = 083a37bd9307ec820bac6ee3c7384083151d36d8
-	etag = 907682e5632a2ba430357e6e042a4ca33cb8c94a3a215d3091aa03f5958a4877
+	sha = c67952501337303eda0fb8b340cb7606666abd8f
+	etag = cb83faed0cc8b930a7b6bdc61bea03a54059858cf04353e55fee94d9e3ae0fad
 	weak
 [file "src/nuget.config"]
 	url = https://github.com/devlooped/oss/blob/main/src/nuget.config
@@ -152,8 +152,8 @@
 	weak
 [file "src/xAI.Protocol/chat.proto"]
 	url = https://github.com/xai-org/xai-proto/blob/main/proto/xai/api/v1/chat.proto
-	sha = c9345abd85649ecb5b27fe8708f573b4ab9d6971
-	etag = a64a560fdac1cb6d349d38b19a58605fa59169879f3d6d517518e573fd137b8c
+	sha = 17a2da08cbbf89aa1f33ffe58b687fe0b2d50468
+	etag = e7da2c915664caf64c0da7d886826de37fcf98753cf613a6ad8aad96f6ddcda5
 	weak
 [file "src/xAI.Protocol/deferred.proto"]
 	url = https://github.com/xai-org/xai-proto/blob/main/proto/xai/api/v1/deferred.proto
@@ -192,8 +192,8 @@
 	weak
 [file "src/xAI.Protocol/usage.proto"]
 	url = https://github.com/xai-org/xai-proto/blob/main/proto/xai/api/v1/usage.proto
-	sha = 362749661fa2d340d234ad372fab920538897821
-	etag = 9fcf9731a547857d554e968968aedc3016fc5210e0a45d5b59d75a03b816a81e
+	sha = d8def643bea79ad10f5a678d70ae37edca26490f
+	etag = 74c44beb7bfd2e75ea0524ff9be820cc067e009b071dee59869a16d372280a0a
 	weak
 [file "src/xAI.Protocol/video.proto"]
 	url = https://github.com/xai-org/xai-proto/blob/main/proto/xai/api/v1/video.proto

--- a/readme.md
+++ b/readme.md
@@ -638,6 +638,7 @@ Uses your own API Key.
 [![Seika Logiciel](https://avatars.githubusercontent.com/u/2564602?v=4&s=39 "Seika Logiciel")](https://github.com/SeikaLogiciel)
 [![Andrew Grant](https://avatars.githubusercontent.com/devlooped-user?s=39 "Andrew Grant")](https://github.com/wizardness)
 [![eska-gmbh](https://avatars.githubusercontent.com/devlooped-team?s=39 "eska-gmbh")](https://github.com/eska-gmbh)
+[![Geodata AS](https://avatars.githubusercontent.com/u/5946299?v=4&s=39 "Geodata AS")](https://github.com/geodata-no)
 
 
 <!-- sponsors.md -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -47,6 +47,9 @@
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <!-- See https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#prunepackagereference-specification -->
     <RestoreEnablePackagePruning>true</RestoreEnablePackagePruning>
+
+    <!-- Needed to improve nuget default for empty PackageId. Workaround for https://github.com/NuGet/Home/issues/14928 -->
+    <ImportNuGetBuildTasksPackTargetsFromSdk>false</ImportNuGetBuildTasksPackTargetsFromSdk>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -32,6 +32,22 @@
     <IsPackable Condition="'$(PackageId)' != ''">true</IsPackable>
   </PropertyGroup>
   
+  <PropertyGroup>
+    <!-- Save original PackageId to restore post-import -->
+    <_PackageId>$(PackageId)</_PackageId>
+    <!-- Since we set ImportNuGetBuildTasksPackTargetsFromSdk=false, the Sdk.targets doesn't even provide the path for this property :/ -->
+    <NuGetBuildTasksPackTargets Condition="'$(NuGetBuildTasksPackTargets)' == ''">$(MSBuildSDKsPath)\..\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
+  </PropertyGroup>
+
+  <Import Project="$(NuGetBuildTasksPackTargets)" Condition="Exists('$(NuGetBuildTasksPackTargets)')"/>
+
+  <PropertyGroup>
+    <!-- Revert the forced PackageId by the NuGet SDK targets for non-packable projects, see https://github.com/NuGet/Home/issues/14928 -->
+    <PackageId Condition="'$(IsPackable)' == 'false'">$(_PackageId)</PackageId>
+    <!-- If no PackageId was originally provided, ensure IsPackable is false -->
+    <IsPackable Condition="'$(_PackageId)' == ''">false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(IsPackable)' == 'true'" Label="NuGet">
     <!-- This is compatible with nugetizer and SDK pack -->
     <!-- Only difference is we don't copy either to output directory -->

--- a/src/xAI.Protocol/chat.proto
+++ b/src/xAI.Protocol/chat.proto
@@ -32,6 +32,12 @@ service Chat {
 
   // Delete a stored response using the response ID.
   rpc DeleteStoredCompletion(DeleteStoredCompletionRequest) returns (DeleteStoredCompletionResponse) {}
+
+  // Compacts a full input context and returns a compacted context.
+  // The client sends the current input items and receives back a compacted
+  // set of items (with an opaque compaction blob) suitable for use as
+  // the input to the next request.
+  rpc CompactContext(CompactContextRequest) returns (CompactContextResponse) {}
 }
 
 message GetCompletionsRequest {
@@ -169,6 +175,10 @@ message GetCompletionsRequest {
   // Number of agents to use for multi-agent models.
   // Only valid when model is a `multi-agent` model. Defaults to `AGENT_COUNT_UNSPECIFIED`.
   optional AgentCount agent_count = 29;
+
+  // Processing tier for this request. Set to SERVICE_TIER_PRIORITY for
+  // higher scheduling priority at a higher price.
+  ServiceTier service_tier = 31;
 }
 
 message GetChatCompletionResponse {
@@ -207,6 +217,13 @@ message GetChatCompletionResponse {
 
   // Debug output. Only available to trusted testers.
   DebugOutput debug_output = 12;
+
+  // Files generated during the response (e.g., by the code execution tool).
+  // Only populated when `INCLUDE_OPTION_CODE_EXECUTION_FILES_OUTPUT` is set.
+  repeated OutputFile output_files = 13;
+
+  // The processing tier that was used for this request.
+  ServiceTier service_tier = 15;
 }
 
 message GetChatCompletionChunk {
@@ -243,6 +260,22 @@ message GetChatCompletionChunk {
 
   // Only available for teams that have debugging privileges.
   DebugOutput debug_output = 10;
+
+  // Files generated during the response (e.g., by the code execution tool).
+  // Only populated for the final chunk when `INCLUDE_OPTION_CODE_EXECUTION_FILES_OUTPUT` is set.
+  repeated OutputFile output_files = 11;
+
+  // The processing tier that was used for this request.
+  ServiceTier service_tier = 12;
+}
+
+// A file generated during a response (e.g., by the code execution tool).
+message OutputFile {
+  // The file ID from the Files API. Use this to download the file.
+  string file_id = 1;
+
+  // The display name of the file.
+  string name = 2;
 }
 
 // Response from GetDeferredCompletion, including the response if the completion
@@ -510,6 +543,9 @@ enum IncludeOption {
   // this option is not included by default.
   // This option is only available for streaming responses.
   INCLUDE_OPTION_VERBOSE_STREAMING = 8;
+
+  // Generated file output from the code execution environment
+  INCLUDE_OPTION_CODE_EXECUTION_FILES_OUTPUT = 9;
 }
 
 // A message in a conversation. This message is part of the model input. Each
@@ -675,6 +711,9 @@ message WebSearch {
   // Setting this will make the agentic search results more relevant to the specified location,
   // which is useful for geolocation-based search results refinement.
   optional WebSearchUserLocation user_location = 4;
+
+  // Enable image search results that can be embedded in responses.
+  optional bool enable_image_search = 5;
 }
 
 // The user location to use for a preference on the search results.
@@ -1126,4 +1165,34 @@ message DebugOutput {
 
   // The tag of the sampler that served this request.
   string sampler_tag = 11;
+}
+
+// ── Context compaction messages ─────────────────────────────────────────
+
+// Request for the standalone CompactContext RPC.
+message CompactContextRequest {
+  // Model to use for generating the compaction blob.
+  string model = 1;
+
+  // Full current input window as proto messages.
+  // This is the same set of messages the client would send in
+  // GetCompletionsRequest.messages.
+  repeated Message input = 2;
+}
+
+// Response from the standalone CompactContext RPC.
+message CompactContextResponse {
+  // Unique compaction ID (e.g. cmp_<uuid>).
+  string id = 1;
+
+  // Opaque blob representing the compacted conversation. Clients must pass
+  // this back unchanged in subsequent requests.
+  string encrypted_content = 2;
+
+  // Number of input Message entries (role + content pairs) from the
+  // original input that were dropped or folded into the compacted blob.
+  uint32 dropped_message_count = 3;
+
+  // Token usage from the compacting model call.
+  SamplingUsage usage = 4;
 }

--- a/src/xAI.Protocol/usage.proto
+++ b/src/xAI.Protocol/usage.proto
@@ -1,5 +1,4 @@
 syntax = "proto3";
-option csharp_namespace = "xAI.Protocol";
 
 package xai_api;
 
@@ -55,6 +54,18 @@ message EmbeddingUsage {
   int32 num_image_embeddings = 2;
 }
 
+// Processing tier for a request. Controls scheduling priority and pricing.
+enum ServiceTier {
+  // Unspecified / default behavior.
+  SERVICE_TIER_UNSPECIFIED = 0;
+
+  // Default processing tier.
+  SERVICE_TIER_DEFAULT = 1;
+
+  // Priority processing tier with higher scheduling priority at a higher price.
+  SERVICE_TIER_PRIORITY = 2;
+}
+
 enum ServerSideTool {
   SERVER_SIDE_TOOL_INVALID = 0;
   SERVER_SIDE_TOOL_WEB_SEARCH = 1;
@@ -65,4 +76,5 @@ enum ServerSideTool {
   SERVER_SIDE_TOOL_COLLECTIONS_SEARCH = 6;
   SERVER_SIDE_TOOL_MCP = 7;
   SERVER_SIDE_TOOL_ATTACHMENT_SEARCH = 8;
+  SERVER_SIDE_TOOL_IMAGE_SEARCH = 10;
 }


### PR DESCRIPTION
# devlooped/oss

- Fix PackageId default from Pack SDK https://github.com/devlooped/oss/commit/6e24389
- Add '/mcps' to .gitignore https://github.com/devlooped/oss/commit/c1d29fb
- Fix empty default path for NuGet SDK targets https://github.com/devlooped/oss/commit/c679525

# xai-org/xai-proto

- fix: correct service_tier field numbers + add code-execution output_files (#65) https://github.com/xai-org/xai-proto/commit/17a2da0
- feat: add ServiceTier enum and service_tier field to chat API (#63) https://github.com/xai-org/xai-proto/commit/d8def64